### PR TITLE
split out `work-cache-prefix` key as mandatory

### DIFF
--- a/stack/cache/restore/action.yaml
+++ b/stack/cache/restore/action.yaml
@@ -3,11 +3,11 @@ description: restore ~/.stack and .stack-work caches on Linux, macOS, and Window
 
 inputs:
   cache-prefix:
-    description: The cache prefix to use for `~/.stack`, e.g. "release" or "ci"
+    description: The cache prefix to use for external packages in `~/.stack`
     required: true
   work-cache-prefix:
-    description: The cache prefix to use for `**/.stack-work`, defaults to the same as `cache-prefix`
-    required: false
+    description: The cache prefix to use for local packages in `**/.stack-work`
+    required: true
   stack-yaml-dir:
     description: The directory to search for `stack.yaml`
     required: false
@@ -28,15 +28,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: set default work cache prefix
-      shell: bash
-      run: |
-        if [ -z "${{inputs.work-cache-prefix}}" ]; then
-          echo "work-cache-prefix=${{inputs.cache-prefix}}" >> "$GITHUB_ENV"
-        else
-          echo "work-cache-prefix=${{inputs.work-cache-prefix}}" >> "$GITHUB_ENV"
-        fi
-
     # The number towards the beginning of the cache keys allow you to manually avoid using a previous cache.
     # GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to
     # purge one manually.
@@ -81,11 +72,11 @@ runs:
         lookup-only: ${{inputs.lookup-only}}
         path: |
           **/.stack-work
-        key: ${{env.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-${{hashFiles('**/stack.yaml', '**/package.yaml')}}-${{hashFiles('**/*.hs')}}
+        key: ${{inputs.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-${{hashFiles('**/stack.yaml', '**/package.yaml')}}-${{hashFiles('**/*.hs')}}
         restore-keys: |
-          ${{env.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-${{hashFiles('**/stack.yaml', '**/package.yaml')}}-
-          ${{env.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-
-          ${{env.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_
+          ${{inputs.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-${{hashFiles('**/stack.yaml', '**/package.yaml')}}-
+          ${{inputs.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-
+          ${{inputs.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_
 
     # we added this step out of necessity, don't exactly remember why.
     # hope to remove it someday.

--- a/stack/cache/save/action.yaml
+++ b/stack/cache/save/action.yaml
@@ -3,11 +3,11 @@ description: save ~/.stack and .stack-work caches on Linux, macOS, and Windows
 
 inputs:
   cache-prefix:
-    description: The cache prefix to use for `~/.stack`, e.g. "release" or "ci"
+    description: The cache prefix to use for external packages in `~/.stack`
     required: true
   work-cache-prefix:
-    description: The cache prefix to use for `**/.stack-work`, defaults to the same as `cache-prefix`
-    required: false
+    description: The cache prefix to use for local packages in `**/.stack-work`
+    required: true
   stack-yaml-dir:
     description: The directory to search for `stack.yaml`
     required: false
@@ -31,7 +31,7 @@ runs:
       uses: unisonweb/actions/stack/cache/restore@main
       with:
         cache-prefix: ${{inputs.cache-prefix}}
-        work-cache-prefix: ${{env.work-cache-prefix}}
+        work-cache-prefix: ${{inputs.work-cache-prefix}}
         stack-yaml-dir: ${{inputs.stack-yaml-dir}}
         lookup-only: true
 
@@ -71,4 +71,4 @@ runs:
       with:
         path: |
           **/.stack-work
-        key: ${{env.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-${{hashFiles('**/stack.yaml', '**/package.yaml')}}-${{hashFiles('**/*.hs')}}
+        key: ${{inputs.work-cache-prefix}}-stack-work-${{runner.os}}-${{runner.arch}}_${{env.resolver}}-${{hashFiles('**/stack.yaml', '**/package.yaml')}}-${{hashFiles('**/*.hs')}}


### PR DESCRIPTION
this should let us share the external dependencies cache without sharing the local build cache